### PR TITLE
Also clean dash separator when removing dates from album names

### DIFF
--- a/ow
+++ b/ow
@@ -242,7 +242,7 @@ def cleanAlbumName(rawAlbumName):
     debug(f'💻 without trailing slash: {noTrailingSlash}')
     based = os.path.basename(noTrailingSlash)
     debug(f'💻 basenamed: {based}')
-    clean = re.sub(r'^\d{4}-\d{2}-\d{2}\s+', '', based)
+    clean = re.sub(r'^\d{4}-\d{2}-\d{2}\s+-?\s*', '', based)
     debug(f'💻 clean album name is {clean}')
     if not clean:
         print(f'⛔ invalid album name: {clean}', file=sys.stderr)


### PR DESCRIPTION
Original code will clean '2024-08-01 Album' to just 'Album'.  This patch will also allow '2024-08-01 - Album' to be cleaned to 'Album' while keeping previous functionality as well.

My folders are named like this, I may not be the only one...